### PR TITLE
Updated for version of Radarr with only v3 API

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -41,7 +41,7 @@ class radarr:
         movie.update({
         "qualityProfileId": self.profileId,
         "rootFolderPath": self.customFolder,
-        "monitored": true,
+        "monitored": "true",
         "addOptions": {
             "searchForMovie":true
         },

--- a/app/api.py
+++ b/app/api.py
@@ -43,7 +43,7 @@ class radarr:
         "rootFolderPath": self.customFolder,
         "monitored": "true",
         "addOptions": {
-            "searchForMovie":true
+            "searchForMovie": "true"
         },
         })
         response = self.post('/movie', json=movie)

--- a/app/api.py
+++ b/app/api.py
@@ -41,8 +41,9 @@ class radarr:
         movie.update({
         "qualityProfileId": self.profileId,
         "rootFolderPath": self.customFolder,
+        "monitored": true,
         "addOptions": {
-            "searchForMovie":True
+            "searchForMovie":true
         },
         })
         response = self.post('/movie', json=movie)

--- a/app/api.py
+++ b/app/api.py
@@ -11,7 +11,7 @@ class radarr:
     def get(self, endpoint, params=None):
         if params:
             params['apikey'] = self.apiKey
-        return requests.get(self.baseUrl + '/api' + endpoint, params=params).json()
+        return requests.get(self.baseUrl + '/api/v3' + endpoint, params=params).json()
 
     def post(self, endpoint, json):
         params = {
@@ -26,7 +26,7 @@ class radarr:
         return response.json()
 
     def searchMovies(self, term, limit=0):
-        data = self.get('/v3/movie/lookup/', {
+        data = self.get('/movie/lookup/', {
             'term':term
         })
         if limit > 0:
@@ -35,25 +35,17 @@ class radarr:
             return data
 
     def getProfiles(self):
-        return self.get('/v3/qualityprofile')
+        return self.get('/qualityprofile')
 
     def addMovie(self, movie):
         movie.update({
-        "monitored":True,
-        "profileId": self.profileId,
-        "episodeFileCount": 0,
-        "episodeCount": 0,
-        "isExisting": False,
-        "saved": False,
-        "deleted": False,
+        "qualityProfileId": self.profileId,
         "rootFolderPath": self.customFolder,
         "addOptions": {
-            "ignoreEpisodesWithFiles":False,
-            "ignoreEpisodesWithoutFiles":False,
             "searchForMovie":True
         },
         })
-        response = self.post('/v3/movie', json=movie)
+        response = self.post('/movie', json=movie)
 
         if response:
             return True

--- a/app/api.py
+++ b/app/api.py
@@ -41,9 +41,9 @@ class radarr:
         movie.update({
         "qualityProfileId": self.profileId,
         "rootFolderPath": self.customFolder,
-        "monitored": "true",
+        "monitored": True,
         "addOptions": {
-            "searchForMovie": "true"
+            "searchForMovie": True
         },
         })
         response = self.post('/movie', json=movie)

--- a/app/api.py
+++ b/app/api.py
@@ -26,7 +26,7 @@ class radarr:
         return response.json()
 
     def searchMovies(self, term, limit=0):
-        data = self.get('/movie/lookup/', {
+        data = self.get('/v3/movie/lookup/', {
             'term':term
         })
         if limit > 0:
@@ -53,7 +53,7 @@ class radarr:
             "searchForMovie":True
         },
         })
-        response = self.post('/movie', json=movie)
+        response = self.post('/v3/movie', json=movie)
 
         if response:
             return True

--- a/app/api.py
+++ b/app/api.py
@@ -8,6 +8,7 @@ class radarr:
         self.profileId = CONFIG['radarr']['profileId']
         self.customFolder = CONFIG['radarr']['folder']
 
+
     def get(self, endpoint, params=None):
         if params:
             params['apikey'] = self.apiKey
@@ -18,7 +19,7 @@ class radarr:
             'apikey':self.apiKey
         }
 
-        response = requests.post(self.baseUrl + '/api' + endpoint, params=params, json=json)
+        response = requests.post(self.baseUrl + '/api/v3' + endpoint, params=params, json=json)
 
         if response.status_code not in ['200', '201']:
             return False


### PR DESCRIPTION
This PR proposes to change the API endpoints to use the v3 version of the Radarr API. The endpoints used in earlier versions of Teleradarr are no longer present in the current version of Radarr. 

Summary of changes
- Change base API endpoint from /api to /api/v3 
- Updated the Quality Profile ID to use the new name ("qualityProfileId")
- Removed extraneous statements from the addMovie method 

This is tested against 4.1.0.6175, however the update may break compatibility with previous versions of Radarr .  